### PR TITLE
add optional list_id foreign key to task table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 TODO
 - [ ] make readme
 - [ ] Postman Runner button in README
-- [ ] Associate tasks for a list (`list_id` foreign key)
+- [x] Associate tasks for a list (`list_id` foreign key)
 - [ ] Simple search mechanics for the tasks all method
 - [ ] Consider authN and authZ implementations

--- a/app/database/task.js
+++ b/app/database/task.js
@@ -6,7 +6,7 @@ const SQL = require('sql-template-strings')
 const db = require('./connection')
 
 const defaultTask = {
-  description: ''
+  content: ''
 }
 
 /**
@@ -28,7 +28,8 @@ async function all (taskId) {
   const query = SQL`
     select
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at
@@ -46,7 +47,8 @@ async function get (taskId) {
   const query = SQL`
     select
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at
@@ -61,17 +63,28 @@ async function get (taskId) {
   return db.getOne(query).then(toTaskModel)
 }
 
-async function create (task = defaultTask) {
+async function create ({ content, list_id, completed_at }) {
+  // @todo support passing in the `task_id` and other properties
+  const task = {
+    ...defaultTask,
+    list_id,
+    content,
+    completed_at
+  }
+
   const query = SQL`
     insert into task (
-      description
+      list_id,
+      content
     )
     values (
-      ${task.description}
+      ${task.list_id || null},
+      ${task.content}
     )
     returning
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at
@@ -93,14 +106,16 @@ async function update (taskId, newTask = {}) {
   const query = SQL`
     update task
     set
-      description = ${task.description},
+      list_id = ${task.list_id},
+      content = ${task.content},
       updated_at = ${new Date()}
     where
       task_id = ${taskId}
       and deleted_at is null
     returning
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at
@@ -138,7 +153,8 @@ async function close (taskId) {
       and deleted_at is null
     returning
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at
@@ -159,7 +175,8 @@ async function reopen (taskId) {
       and deleted_at is null
     returning
       task_id,
-      description,
+      list_id,
+      content,
       completed_at,
       created_at,
       updated_at

--- a/migrations/20170915021713-add-fk-list-id-to-task.js
+++ b/migrations/20170915021713-add-fk-list-id-to-task.js
@@ -1,0 +1,29 @@
+/**
+ * @overview adds a `list_id` foreign key `task` table
+ * This applies a `ON DELETE SET NULL` rule, such that orphaned tasks (when a list is deleted) are still around
+ * This is particularly useful if we want a generic "inbox" kind of catch-all for any tasks that belong to no list
+ */
+
+const table = 'task'
+const columnName = 'list_id'
+const columnSpec = {
+  type: 'uuid'
+}
+
+const referencedColumn = 'list_id'
+const referencedTable = 'list'
+const foreignKeyName = 'task_list_id_foreign_key'
+const fieldMapping = { [columnName]: referencedColumn }
+const rules = { onDelete: 'SET NULL' }
+
+exports.up = function (db) {
+  return db.addColumn(table, columnName, columnSpec).then(() => {
+    return db.addForeignKey(table, referencedTable, foreignKeyName, fieldMapping, rules)
+  })
+}
+
+exports.down = function (db) {
+  return db.removeForeignKey(table, foreignKeyName).then(() => {
+    return db.removeColumn(table, columnName)
+  })
+}

--- a/migrations/20170915031757-rename-description-column-to-content.js
+++ b/migrations/20170915031757-rename-description-column-to-content.js
@@ -1,0 +1,15 @@
+/**
+ * @overview renames the `description` column to `content`
+ */
+
+const tableName = 'task'
+const oldColumnName = 'description'
+const newColumnName = 'content'
+
+exports.up = function (db) {
+  return db.renameColumn(tableName, oldColumnName, newColumnName)
+}
+
+exports.down = function (db) {
+  return db.renameColumn(tableName, newColumnName, oldColumnName)
+}


### PR DESCRIPTION
This also renamed the `task.description` column to `content` which is less semantically misleading, albeit more generic.