### PR TITLE
apply request validation on params/body

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Migrations are implemented via `db-migrate` – if you want to have full contro
 ## TODO
 
 - [x] Associate tasks for a list (`list_id` foreign key)
-- [x] make readme
+- [x] Make readme
+- [x] Validate input params for route handlers
 - [ ] Simple search mechanics for the tasks all method
+- [ ] Support `PATCH` partial updates for tasks and lists
 - [ ] Postman Runner button in README
 - [ ] Consider authN and authZ implementations
 - [ ] Dockerize? Deal with Postgres persistence

--- a/app/database/task.js
+++ b/app/database/task.js
@@ -100,7 +100,6 @@ async function update (taskId, newTask = {}) {
     return null
   }
 
-  // @todo only update the props that have been provided?
   const task = Object.assign({}, oldTask, newTask)
 
   const query = SQL`

--- a/app/middleware/errors.js
+++ b/app/middleware/errors.js
@@ -6,7 +6,6 @@
 
 const { NotFound } = require('http-errors')
 const flatten = require('lodash/flatten')
-const { ValidationError } = require('express-json-validator-middleware')
 
 /**
  * Middleware to handle response for errors
@@ -19,7 +18,7 @@ function handleErrorResponse (err, req, res, next) {
   const message = err.message || 'Server Error'
   const errors = []
 
-  if (err instanceof ValidationError && err.validationErrors) {
+  if (err.validationErrors) {
     const propErrors = flatten(Object.values(err.validationErrors)).map(prop => {
       return {
         path: prop.dataPath,

--- a/app/middleware/validation.js
+++ b/app/middleware/validation.js
@@ -1,0 +1,46 @@
+/**
+ * @overview Express middleware for request validation (body, params, query, etc.) using Ajv/json-schema
+ */
+
+const { BadRequest } = require('http-errors')
+const Validator = require('../schema/validator')
+
+/**
+ * Express middleware that can be used as normal middleware or a route handler higher order function
+ * @param {Object} schemas - properties mapping to JSON schemas for validation
+ * @param {Function} fn - optional callback function, to use as `withValidation(schemas, (req, res, next) => {})`
+ * @example
+ *  withValidation({
+ *    body: {
+ *      type: 'object',
+ *      required: ['foo'],
+ *      properties: {
+ *        foo: {
+ *          type: 'string'
+ *        }
+ *      }
+ *    }
+ *  },
+ *  (req, res, next) => {
+ *    res.send('no errors!')
+ *  })
+ */
+module.exports = function withValidation (schemas, fn) {
+  const validator = new Validator({ allErrors: true }, schemas)
+
+  return (req, res, next) => {
+    const errors = validator.validate(req)
+
+    if (errors) {
+      const badRequest = new BadRequest()
+      badRequest.validationErrors = errors
+      return next(badRequest)
+    }
+
+    if (typeof fn === 'function') {
+      fn(req, res, next)
+    } else {
+      next()
+    }
+  }
+}

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,8 +3,7 @@
  */
 
 const router = require('express').Router()
-const { Validator } = require('express-json-validator-middleware')
-const validator = new Validator({ allErrors: true })
+const withValidation = require('../middleware/validation')
 
 /** shim for handling async errors, so you can simply `throw` in async request handlers */
 require('express-async-errors')
@@ -12,41 +11,36 @@ require('express-async-errors')
 const lists = require('./lists')
 const tasks = require('./tasks')
 
-function requireUuidParam (paramName) {
-  return {
-    type: 'object',
-    properties: {
-      [paramName]: {
-        type: 'string',
-        format: 'uuid'
-      }
-    },
-    required: [paramName]
-  }
+const id = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+      format: 'uuid'
+    }
+  },
+  required: ['id']
 }
-
-const listIdParam = requireUuidParam('listId')
-const taskIdParam = requireUuidParam('taskId')
 
 /** list handlers */
 router.get('/lists', lists.getLists)
 router.post('/lists', lists.createList)
-router.all('/lists/:listId', validator.validate({ params: listIdParam }))
-  .get('/lists/:listId', lists.getList)
-  .put('/lists/:listId', lists.updateList)
-  .patch('/lists/:listId', lists.patchList)
-  .delete('/lists/:listId', lists.deleteList)
-  .post('/lists/:listId/archive', lists.archiveList)
+router.all('/lists/:id', withValidation({ params: id }))
+  .get('/lists/:id', lists.getList)
+  .put('/lists/:id', lists.updateList)
+  .patch('/lists/:id', lists.patchList)
+  .delete('/lists/:id', lists.deleteList)
+  .post('/lists/:id/archive', lists.archiveList)
 
 /** task handlers */
 router.get('/tasks', tasks.getTasks)
 router.post('/tasks', tasks.createTask)
-router.all('/tasks/:taskId', validator.validate({ params: taskIdParam }))
-  .get('/tasks/:taskId', tasks.getTask)
-  .put('/tasks/:taskId', tasks.updateTask)
-  .patch('/tasks/:taskId', tasks.patchTask)
-  .delete('/tasks/:taskId', tasks.deleteTask)
-  .post('/tasks/:taskId/close', tasks.closeTask)
-  .post('/tasks/:taskId/reopen', tasks.reopenTask)
+router.all('/tasks/:id', withValidation({ params: id }))
+  .get('/tasks/:id', tasks.getTask)
+  .put('/tasks/:id', tasks.updateTask)
+  .patch('/tasks/:id', tasks.patchTask)
+  .delete('/tasks/:id', tasks.deleteTask)
+  .post('/tasks/:id/close', tasks.closeTask)
+  .post('/tasks/:id/reopen', tasks.reopenTask)
 
 module.exports = router

--- a/app/routes/lists.js
+++ b/app/routes/lists.js
@@ -4,18 +4,20 @@
 
 const { NotFound } = require('http-errors')
 const { List } = require('../database')
+const withValidation = require('../middleware/validation')
+const schema = require('../schema/list')
 
-function listNotFound (listId) {
-  return new NotFound(`No list found with id: '${listId}'`)
+function listNotFound (id) {
+  return new NotFound(`No list found with id: '${id}'`)
 }
 
-async function getLists (req, res) {
+exports.getLists = async function getLists (req, res) {
   const lists = await List.all()
   res.status(200).json(lists)
 }
 
-async function getList (req, res) {
-  const id = req.params.listId
+exports.getList = async function getList (req, res) {
+  const id = req.params.id
   const list = await List.get(id)
 
   if (list) {
@@ -25,39 +27,42 @@ async function getList (req, res) {
   }
 }
 
-// @todo validate input params
-async function createList (req, res) {
-  const list = await List.create(req.body)
-  res.status(201).json(list)
-}
-
-// @todo validate input params
-async function updateList (req, res) {
-  const id = req.params.listId
-  const list = await List.update(id, req.body)
-
-  if (list) {
-    res.status(200).json(list)
-  } else {
-    throw listNotFound(id)
+exports.createList = withValidation({ body: schema },
+  async function createList (req, res) {
+    const list = await List.create(req.body)
+    res.status(201).json(list)
   }
-}
+)
 
-// @todo validate input params
+exports.updateList = withValidation({ body: schema },
+  async function updateList (req, res) {
+    const id = req.params.id
+    const list = await List.update(id, req.body)
+
+    if (list) {
+      res.status(200).json(list)
+    } else {
+      throw listNotFound(id)
+    }
+  }
+)
+
 // @todo implement patch
-async function patchList (req, res) {
-  const id = req.params.listId
-  const list = await List.update(id, req.body)
+exports.patchList = withValidation({ body: schema },
+  async function patchList (req, res) {
+    const id = req.params.id
+    const list = await List.update(id, req.body)
 
-  if (list) {
-    res.status(200).json(list)
-  } else {
-    throw listNotFound(id)
+    if (list) {
+      res.status(200).json(list)
+    } else {
+      throw listNotFound(id)
+    }
   }
-}
+)
 
-async function deleteList (req, res) {
-  const id = req.params.listId
+exports.deleteList = async function deleteList (req, res) {
+  const id = req.params.id
   const list = await List.destroy(id)
 
   if (list) {
@@ -67,8 +72,8 @@ async function deleteList (req, res) {
   }
 }
 
-async function archiveList (req, res) {
-  const id = req.params.listId
+exports.archiveList = async function archiveList (req, res) {
+  const id = req.params.id
   const list = await List.archive(id)
 
   if (list) {
@@ -76,14 +81,4 @@ async function archiveList (req, res) {
   } else {
     throw listNotFound(id)
   }
-}
-
-module.exports = {
-  getLists,
-  getList,
-  createList,
-  updateList,
-  patchList,
-  deleteList,
-  archiveList
 }

--- a/app/routes/tasks.js
+++ b/app/routes/tasks.js
@@ -4,18 +4,20 @@
 
 const { NotFound } = require('http-errors')
 const { Task } = require('../database')
+const withValidation = require('../middleware/validation')
+const schema = require('../schema/task')
 
-function taskNotFound (taskId) {
-  return new NotFound(`No task found with id: '${taskId}'`)
+function taskNotFound (id) {
+  return new NotFound(`No task found with id: '${id}'`)
 }
 
-async function getTasks (req, res) {
+exports.getTasks = async function getTasks (req, res) {
   const tasks = await Task.all()
   res.status(200).json(tasks)
 }
 
-async function getTask (req, res) {
-  const id = req.params.taskId
+exports.getTask = async function getTask (req, res) {
+  const id = req.params.id
   const task = await Task.get(id)
 
   if (task) {
@@ -25,39 +27,42 @@ async function getTask (req, res) {
   }
 }
 
-// @todo validate input params
-async function createTask (req, res) {
-  const task = await Task.create(req.body)
-  res.status(201).json(task)
-}
-
-// @todo validate input params
-async function updateTask (req, res) {
-  const id = req.params.taskId
-  const task = await Task.update(id, req.body)
-
-  if (task) {
-    res.status(200).json(task)
-  } else {
-    throw taskNotFound(id)
+exports.createTask = withValidation({ body: schema },
+  async function createTask (req, res) {
+    const task = await Task.create(req.body)
+    res.status(201).json(task)
   }
-}
+)
 
-// @todo validate input params
+exports.updateTask = withValidation({ body: schema },
+  async function updateTask (req, res) {
+    const id = req.params.id
+    const task = await Task.update(id, req.body)
+
+    if (task) {
+      res.status(200).json(task)
+    } else {
+      throw taskNotFound(id)
+    }
+  }
+)
+
 // @todo implement patch
-async function patchTask (req, res) {
-  const id = req.params.taskId
-  const task = await Task.update(id, req.body)
+exports.patchTask = withValidation({ body: schema },
+  async function patchTask (req, res) {
+    const id = req.params.id
+    const task = await Task.update(id, req.body)
 
-  if (task) {
-    res.status(200).json(task)
-  } else {
-    throw taskNotFound(id)
+    if (task) {
+      res.status(200).json(task)
+    } else {
+      throw taskNotFound(id)
+    }
   }
-}
+)
 
-async function deleteTask (req, res) {
-  const id = req.params.taskId
+exports.deleteTask = async function deleteTask (req, res) {
+  const id = req.params.id
   const task = await Task.destroy(id)
 
   if (task) {
@@ -67,8 +72,8 @@ async function deleteTask (req, res) {
   }
 }
 
-async function closeTask (req, res) {
-  const id = req.params.taskId
+exports.closeTask = async function closeTask (req, res) {
+  const id = req.params.id
   const task = await Task.close(id)
 
   if (task) {
@@ -78,8 +83,8 @@ async function closeTask (req, res) {
   }
 }
 
-async function reopenTask (req, res) {
-  const id = req.params.taskId
+exports.reopenTask = async function reopenTask (req, res) {
+  const id = req.params.id
   const task = await Task.reopen(id)
 
   if (task) {
@@ -87,15 +92,4 @@ async function reopenTask (req, res) {
   } else {
     throw taskNotFound(id)
   }
-}
-
-module.exports = {
-  getTasks,
-  getTask,
-  createTask,
-  updateTask,
-  patchTask,
-  deleteTask,
-  closeTask,
-  reopenTask
 }

--- a/app/schema/list.js
+++ b/app/schema/list.js
@@ -1,0 +1,17 @@
+/**
+ * @overview list schema
+ */
+
+const schemaTypes = require('./types')
+
+module.exports = {
+  type: 'object',
+  properties: {
+    list_id: schemaTypes.uuid,
+    name: schemaTypes.string,
+    archived_at: schemaTypes.date
+  },
+  required: [
+    'name'
+  ]
+}

--- a/app/schema/task.js
+++ b/app/schema/task.js
@@ -1,0 +1,19 @@
+/**
+ * @overview task schema
+ */
+
+const schemaTypes = require('./types')
+
+module.exports = {
+  type: 'object',
+  properties: {
+    task_id: schemaTypes.uuid,
+    list_id: schemaTypes.uuid,
+    content: schemaTypes.string,
+    completed: schemaTypes.boolean,
+    completed_at: schemaTypes.date
+  },
+  required: [
+    'content'
+  ]
+}

--- a/app/schema/types.js
+++ b/app/schema/types.js
@@ -1,0 +1,21 @@
+/**
+ * @overview schema types
+ */
+
+exports.boolean = {
+  type: 'boolean'
+}
+
+exports.date = {
+  type: 'string',
+  format: 'date-time'
+}
+
+exports.string = {
+  type: 'string'
+}
+
+exports.uuid = {
+  type: 'string',
+  format: 'uuid'
+}

--- a/app/schema/validator.js
+++ b/app/schema/validator.js
@@ -1,0 +1,22 @@
+/**
+ * @overview schema validation class
+ */
+
+const Ajv = require('ajv')
+
+class Validator {
+  constructor (options, schemas) {
+    const ajv = new Ajv(options)
+    this.validator = ajv.compile({
+      type: 'object',
+      properties: schemas
+    })
+  }
+
+  validate (obj) {
+    const valid = this.validator(obj)
+    return valid ? null : this.validator.errors
+  }
+}
+
+module.exports = Validator

--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,25 +1010,6 @@
       "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-2.0.0.tgz",
       "integrity": "sha1-KaQ0zUSvIqr4zGMrga1AAdl7Lkg="
     },
-    "express-json-validator-middleware": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/express-json-validator-middleware/-/express-json-validator-middleware-1.0.4.tgz",
-      "integrity": "sha1-WfZCMouYnLpxYzIDKDxcy5OuURw=",
-      "requires": {
-        "ajv": "4.11.8"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        }
-      }
-    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "db-migrate-pg": "^0.2.5",
     "express": "^4.15.4",
     "express-async-errors": "^2.0.0",
-    "express-json-validator-middleware": "^1.0.4",
     "helmet": "^3.8.1",
     "http-errors": "^1.6.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This provides a middleware function `withValidation` that allows you to wrap request properties with [Ajv](https://github.com/epoberezkin/ajv) (which uses the latest draft for json schema validation).

Other bits:
- [x] create json schemas for lists and tasks
- [x] apply param validation for all CRUD methods on a particular task or list record
- [x] apply body validation for all C*UD method on a particular task or list record