### PR TITLE
add simple filters for lists and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Migrations are implemented via `db-migrate` – if you want to have full contro
 - [x] Associate tasks for a list (`list_id` foreign key)
 - [x] Make readme
 - [x] Validate input params for route handlers
-- [ ] Simple search mechanics for the tasks all method
+- [x] Simple search mechanics for the tasks all method
+- [ ] Add versioning support
+- [ ] Add tests
 - [ ] Support `PATCH` partial updates for tasks and lists
 - [ ] Postman Runner button in README
 - [ ] Consider authN and authZ implementations

--- a/app/routes/lists.js
+++ b/app/routes/lists.js
@@ -12,7 +12,7 @@ function listNotFound (id) {
 }
 
 exports.getLists = async function getLists (req, res) {
-  const lists = await List.all()
+  const lists = await List.all(req.query)
   res.status(200).json(lists)
 }
 

--- a/app/routes/tasks.js
+++ b/app/routes/tasks.js
@@ -12,7 +12,7 @@ function taskNotFound (id) {
 }
 
 exports.getTasks = async function getTasks (req, res) {
-  const tasks = await Task.all()
+  const tasks = await Task.all(req.query)
   res.status(200).json(tasks)
 }
 

--- a/app/schema/list.js
+++ b/app/schema/list.js
@@ -9,7 +9,9 @@ module.exports = {
   properties: {
     list_id: schemaTypes.uuid,
     name: schemaTypes.string,
-    archived_at: schemaTypes.date
+    archived_at: {
+      anyOf: [schemaTypes.date, schemaTypes.null]
+    }
   },
   required: [
     'name'

--- a/app/schema/task.js
+++ b/app/schema/task.js
@@ -8,10 +8,14 @@ module.exports = {
   type: 'object',
   properties: {
     task_id: schemaTypes.uuid,
-    list_id: schemaTypes.uuid,
+    list_id: {
+      anyOf: [schemaTypes.uuid, schemaTypes.null]
+    },
     content: schemaTypes.string,
     completed: schemaTypes.boolean,
-    completed_at: schemaTypes.date
+    completed_at: {
+      anyOf: [schemaTypes.date, schemaTypes.null]
+    }
   },
   required: [
     'content'

--- a/app/schema/types.js
+++ b/app/schema/types.js
@@ -19,3 +19,7 @@ exports.uuid = {
   type: 'string',
   format: 'uuid'
 }
+
+exports.null = {
+  type: 'null'
+}


### PR DESCRIPTION
This adds the ability to query for tasks and lists with some basic filters.

### `GET /api/lists?archived=`
Param | Value | Description
------------ | ------------- | -------------
`archived` | `true, false` | returns only archived, or unarchived lists

### `GET /api/tasks?completed=&list_id=`
Param | Value | Description
------------ | ------------- | -------------
`completed` | `true, false` | returns only complete, or incomplete tasks
`list_id` | `uuid` | the id of a particular list. returns only tasks associated with that list.
