### PR TITLE
setup dockerfile and docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# add git-ignore syntax here of things you don't want copied into docker image
+
+# git stuff
+.git
+.gitignore
+
+# docker stuff
+*Dockerfile*
+*docker-compose*
+docker/*
+
+# node stuff
+node_modules
+
+# misc
+.DS_Store
+*.log
+.env
+.nvmrc
+.editorconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# largely inspired by https://github.com/BretFisher/node-docker-good-defaults/blob/master/Dockerfile
+
+FROM node:8.10-slim
+
+RUN mkdir -p /opt/app
+
+# set our node environment, either development or production
+# defaults to production, compose overrides this to development on build and run
+ARG NODE_ENV=production
+ENV NODE_ENV $NODE_ENV
+
+# default to port 8080 for node, and 5858 or 9229 for debug
+ARG PORT=80
+ENV PORT $PORT
+EXPOSE $PORT 5858 9229
+
+# check every 30s to ensure this service returns HTTP 200
+HEALTHCHECK CMD curl -fs http://localhost:$PORT/health || exit 1
+
+# install dependencies first, in a different location for easier app bind mounting for local development
+WORKDIR /opt
+COPY package.json package-lock.json* ./
+RUN npm install --no-optional
+ENV PATH /opt/node_modules/.bin:$PATH
+
+# copy in our source code last, as it changes the most
+WORKDIR /opt/app
+COPY config ./config/
+COPY migrations ./migrations/
+COPY app ./app/
+COPY database.json ./
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A REST api for managing tasks and lists.
 
 ## Requirements
 
-- Node >= 8.x
-- npm >= 5.x
+- Node >= 8.8
+- npm >= 5.5
 - Postgresql 9.x
 
 It's recommended that you use [`nvm`](https://github.com/creationix/nvm) to manage Node versions
@@ -17,6 +17,22 @@ It's recommended that you use [`nvm`](https://github.com/creationix/nvm) to mana
 ### Dependencies
 
 Once you've got Node/npm installed you can run `npm install` to install app dependencies. It is recommended you do this prior to getting the database configured if you want to make use of the `npm run migrate` command.
+
+### Running locally via Docker
+
+This project uses Docker for local development, and the Dockerfile can also be used for production. `docker-compose` provides a clean interface for doing local development and overriding production defaults.
+
+#### Requirements to run via Docker
+- `Docker` should be installed, supporting `docker-compose` v3.1
+- Have postgres configured in `environment.json`. If you don't want to locally install postgres but would rather connect to a remote instance you will need to change the `PGHOST` environment variable specified in `docker-compose`
+
+#### Build and run the app
+
+Once you've got Docker installed and postgres installed (or a remote instance), you can build and run the app. You can use one simple command to do the whole thing:
+
+- `docker-compose up`
+
+Of course, you can also manually build the `Dockerfile` with your own flags, but `docker-compose` make running the app quite simple.
 
 ### Database and migrations
 
@@ -42,7 +58,7 @@ Migrations are implemented via `db-migrate` – if you want to have full contro
 - [ ] Add tests
 - [ ] Add task sort ordering
 - [ ] Support `PATCH` partial updates for tasks and lists
-- [ ] Dockerize? Deal with Postgres persistence
+- [x] Dockerize? Deal with Postgres persistence (decided against PG in a mounted volume – aka dont use containers for PG)
 - [ ] Consider authN and authZ implementations
 - [ ] Consider sharing
 - [ ] Rate limiting

--- a/app/database/connection.js
+++ b/app/database/connection.js
@@ -14,7 +14,8 @@ const pool = new Pool({
   port: config.get('PGPORT') || 5432,
   user: config.get('PGUSER'),
   password: config.get('PGPASSWORD'),
-  database: config.get('PGDATABASE')
+  database: config.get('PGDATABASE'),
+  connectionString: config.get('DATABASE_URL')
 })
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.1'
+
+services:
+  api:
+    container_name: api
+    build:
+      context: ./
+      args:
+        - NODE_ENV=development
+        - PORT=3000
+    ports:
+      - '3000:3000'
+      - '5858:5858'
+      - '9229:9229'
+    volumes:
+      - .:/opt/app:delegated
+      # this is a workaround to prevent host node_modules from accidently getting mounted in container
+      # in case you want to use node/npm both outside container for test/lint etc. and also inside container
+      # this will overwrite the default node_modules dir in container so it won't conflict with our
+      # /opt/node_modules location. Thanks to PR from @brnluiz
+      - notused:/opt/app/node_modules
+    environment:
+      - NODE_ENV=development
+      - PGHOST=docker.for.mac.localhost
+
+volumes:
+  notused:

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "app/server.js",
   "private": true,
   "engines": {
-    "node": ">=8.x",
-    "npm": ">=5.x"
+    "node": ">=8.8",
+    "npm": ">=5.5"
   },
   "scripts": {
     "lint": "standard --fix config app",

--- a/scripts/initdb.sql
+++ b/scripts/initdb.sql
@@ -1,0 +1,3 @@
+-- install pgcrypto exension
+\c minimalist
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";

--- a/setup-db.sql
+++ b/setup-db.sql
@@ -1,5 +1,0 @@
-DROP DATABASE IF EXISTS minimalist;
-CREATE DATABASE minimalist;
-
-\c minimalist
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";


### PR DESCRIPTION
This PR adds Docker support to build and run the app. You can now use `docker-compose up` as a single command to stand up a local instance.

Postgres was intentionally omitted. I experimented with using Docker volumes to mount and persist postgres data, which seems really really convenient, but decided to heed the excessive warnings on The Internet against putting databases in containers. Plus I would likely need to separate the database out in the future, should the service grow beyond a hobby.

Note: `docker-compose.yml` is not intended for use in production here. It's merely for simplifying local development using Docker. 