### PR TITLE
add validation on entities before insert/update (on "save")

### DIFF
--- a/app/models/list/__tests__/list.entity.test.ts
+++ b/app/models/list/__tests__/list.entity.test.ts
@@ -1,4 +1,8 @@
+import Chance from 'chance'
 import List from '../list.entity'
+
+const chance = new Chance()
+const viewer = chance.guid({ version: 4 })
 
 describe('List', () => {
   describe('isArchived', () => {
@@ -36,6 +40,24 @@ describe('List', () => {
       list.isArchived = false
 
       expect(list.archivedAt).toBe(null)
+    })
+  })
+
+  describe('validate', () => {
+    it('should throw when a list has invalid values', async () => {
+      const list = new List()
+      list.name = ''
+      list.createdBy = viewer
+
+      await expect(list.validate()).rejects.toThrowError(/Invalid data. Check "errors" for more details./)
+    })
+
+    it('should not throw when a list has valid values', async () => {
+      const list = new List()
+      list.name = 'Valid Name'
+      list.createdBy = viewer
+
+      await expect(list.validate()).resolves.not.toThrow()
     })
   })
 })

--- a/app/models/list/index.ts
+++ b/app/models/list/index.ts
@@ -1,7 +1,7 @@
 import { Forbidden, NotFound, Unauthorized } from 'http-errors'
 import { get } from 'lodash'
 import { getCustomRepository, FindOneOptions } from 'typeorm'
-import { Viewer } from '../../types'
+import { Viewer, UUID } from '../../types'
 import List from './list.entity'
 import ListRepository from './list.repository'
 
@@ -29,7 +29,7 @@ export class ListModel {
   /**
    * Gets a list if the viewer has access to it
    */
-  static async fetch(viewer: Viewer, id: string, options?: { withTasks?: boolean }): Promise<List | null> {
+  static async fetch(viewer: Viewer, id: UUID, options?: { withTasks?: boolean }): Promise<List | null> {
     if (!viewer) {
       return null
     }
@@ -50,7 +50,7 @@ export class ListModel {
   /**
    * Get all lists created by the viewer
    */
-  static async fetchAllByViewer(viewer: Viewer, ids?: string[]): Promise<List[]> {
+  static async fetchAllByViewer(viewer: Viewer, ids?: UUID[]): Promise<List[]> {
     if (!viewer) {
       return []
     }
@@ -80,7 +80,7 @@ export class ListModel {
    * Updates a list for the viewer given some attributes
    * @todo validate `attrs`
    */
-  static async update(viewer: Viewer, id: string, attrs: Partial<List>): Promise<List> {
+  static async update(viewer: Viewer, id: UUID, attrs: Partial<List>): Promise<List> {
     const list = await ListModel.fetch(viewer, id)
     if (!list) {
       throw new NotFound(`No list found with id "${id}"`)
@@ -95,7 +95,7 @@ export class ListModel {
   /**
    * Archives a list for the viewer
    */
-  static async archive(viewer: Viewer, id: string): Promise<List> {
+  static async archive(viewer: Viewer, id: UUID): Promise<List> {
     const list = await ListModel.fetch(viewer, id)
     if (!list) {
       throw new NotFound(`No list found with id "${id}"`)
@@ -107,7 +107,7 @@ export class ListModel {
   /**
    * Unarchives a list for the viewer
    */
-  static async unarchive(viewer: Viewer, id: string): Promise<List> {
+  static async unarchive(viewer: Viewer, id: UUID): Promise<List> {
     const list = await ListModel.fetch(viewer, id)
     if (!list) {
       throw new NotFound(`No list found with id "${id}"`)
@@ -119,7 +119,7 @@ export class ListModel {
   /**
    * Deletes a list if the viewer has access
    */
-  static async delete(viewer: Viewer, id: string): Promise<void> {
+  static async delete(viewer: Viewer, id: UUID): Promise<void> {
     const list = await ListModel.fetch(viewer, id)
 
     // viewer can only delete their own lists

--- a/app/models/list/list.repository.ts
+++ b/app/models/list/list.repository.ts
@@ -1,5 +1,6 @@
 import { EntityRepository, Repository } from 'typeorm'
 import List from './list.entity'
+import { UUID } from '../../types'
 
 @EntityRepository(List)
 export default class ListRepository extends Repository<List> {
@@ -8,7 +9,7 @@ export default class ListRepository extends Repository<List> {
    * TODO: pagination?
    * TODO: filters?
    */
-  public async allByAuthor(authorId: string, ids?: string[]): Promise<List[]> {
+  public async allByAuthor(authorId: UUID, ids?: UUID[]): Promise<List[]> {
     let query = this.createQueryBuilder('list').where({ createdBy: authorId })
 
     if (ids && ids.length > 0) {

--- a/app/models/task/__tests__/task.entity.test.ts
+++ b/app/models/task/__tests__/task.entity.test.ts
@@ -1,4 +1,7 @@
+import Chance from 'chance'
 import Task from '../task.entity'
+
+const chance = new Chance()
 
 describe('Task', () => {
   describe('isCompleted', () => {
@@ -35,6 +38,21 @@ describe('Task', () => {
 
       task.isCompleted = false
       expect(task.completedAt).toBe(null)
+    })
+  })
+
+  describe('validate', () => {
+    it('should throw when a list has invalid values', async () => {
+      const task = new Task()
+      await expect(task.validate()).rejects.toThrowError(/Invalid data. Check "errors" for more details./)
+    })
+
+    it('should not throw when a list has valid values', async () => {
+      const task = new Task()
+      task.content = ''
+      task.createdBy = chance.guid({ version: 4 })
+
+      await expect(task.validate()).resolves.not.toThrow()
     })
   })
 })

--- a/app/models/task/index.ts
+++ b/app/models/task/index.ts
@@ -1,6 +1,6 @@
 import { BadRequest, Forbidden, NotFound, Unauthorized } from 'http-errors'
 import { getCustomRepository } from 'typeorm'
-import { Viewer } from '../../types'
+import { Viewer, UUID } from '../../types'
 import { canViewList, canEditList, ListModel } from '../list'
 import Task from './task.entity'
 import TaskRepository from './task.repository'
@@ -36,7 +36,7 @@ export class TaskModel {
   /**
    * Gets a task if the viewer has access to it
    */
-  static async fetch(viewer: Viewer, id: string): Promise<Task | null> {
+  static async fetch(viewer: Viewer, id: UUID): Promise<Task | null> {
     if (!viewer) {
       return null
     }
@@ -53,7 +53,7 @@ export class TaskModel {
   /**
    * Gets all tasks associated with a list
    */
-  static async fetchAllByList(viewer: Viewer, listId: string): Promise<Task[]> {
+  static async fetchAllByList(viewer: Viewer, listId: UUID): Promise<Task[]> {
     if (!viewer) {
       return []
     }
@@ -71,7 +71,7 @@ export class TaskModel {
   /**
    * Gets all tasks that a viewer has access to
    */
-  static async fetchAllByViewer(viewer: Viewer, ids?: string[]): Promise<Task[]> {
+  static async fetchAllByViewer(viewer: Viewer, ids?: UUID[]): Promise<Task[]> {
     if (!viewer) {
       return []
     }
@@ -85,7 +85,7 @@ export class TaskModel {
    */
   static async create(
     viewer: Viewer,
-    attrs: { content?: string; completedAt?: Date | string | null; isCompleted?: boolean; listId?: string }
+    attrs: { content?: string; completedAt?: Date | string | null; isCompleted?: boolean; listId?: UUID }
   ): Promise<Task> {
     if (!viewer) {
       throw new Unauthorized(`Must be logged in create tasks.`)
@@ -114,7 +114,7 @@ export class TaskModel {
    * Updates a task for the viewer given some attributes
    * @todo validate `attrs`
    */
-  static async update(viewer: Viewer, id: string, attrs: Partial<Task>): Promise<Task> {
+  static async update(viewer: Viewer, id: UUID, attrs: Partial<Task>): Promise<Task> {
     const task = await TaskModel.fetch(viewer, id)
     if (!task) {
       throw new NotFound(`No task found with id "${id}"`)
@@ -126,7 +126,7 @@ export class TaskModel {
   /**
    * Marks a task complete for the viewer
    */
-  static async markComplete(viewer: Viewer, id: string): Promise<Task> {
+  static async markComplete(viewer: Viewer, id: UUID): Promise<Task> {
     const task = await TaskModel.fetch(viewer, id)
     if (!task) {
       throw new NotFound(`No task found with id "${id}"`)
@@ -138,7 +138,7 @@ export class TaskModel {
   /**
    * Marks a task incomplete for the viewer
    */
-  static async markIncomplete(viewer: Viewer, id: string): Promise<Task> {
+  static async markIncomplete(viewer: Viewer, id: UUID): Promise<Task> {
     const task = await TaskModel.fetch(viewer, id)
     if (!task) {
       throw new NotFound(`No task found with id "${id}"`)
@@ -150,7 +150,7 @@ export class TaskModel {
   /**
    * Deletes a task if the viewer has access
    */
-  static async delete(viewer: Viewer, id: string): Promise<void> {
+  static async delete(viewer: Viewer, id: UUID): Promise<void> {
     const task = await TaskModel.fetch(viewer, id)
 
     if (!task || !(await canEditTask(viewer, task))) {

--- a/app/models/task/task.repository.ts
+++ b/app/models/task/task.repository.ts
@@ -1,5 +1,6 @@
 import { EntityRepository, Repository } from 'typeorm'
 import Task from './task.entity'
+import { UUID } from '../../types'
 
 @EntityRepository(Task)
 export default class TaskRepository extends Repository<Task> {
@@ -8,7 +9,7 @@ export default class TaskRepository extends Repository<Task> {
    * TODO: pagination?
    * TODO: filters?
    */
-  public allByAuthor(author: string, ids?: string[]): Promise<Task[]> {
+  public allByAuthor(author: UUID, ids?: UUID[]): Promise<Task[]> {
     let query = this.createQueryBuilder('task').where({ createdBy: author })
 
     if (ids && ids.length > 0) {

--- a/app/models/user/index.ts
+++ b/app/models/user/index.ts
@@ -1,6 +1,6 @@
 import { Conflict, Forbidden } from 'http-errors'
 import { getCustomRepository } from 'typeorm'
-import { Viewer } from '../../types'
+import { Viewer, UUID } from '../../types'
 import User from './user.entity'
 import UserRepository from './user.repository'
 
@@ -43,7 +43,7 @@ export class UserModel {
   /**
    * Creates a user given some attributes
    */
-  static async create(_viewer: Viewer, attrs: { id?: string; email: string; password: string }): Promise<User> {
+  static async create(_viewer: Viewer, attrs: { id?: UUID; email: string; password: string }): Promise<User> {
     const repo = getCustomRepository(UserRepository)
 
     if (await repo.findByEmail(attrs.email)) {
@@ -57,7 +57,7 @@ export class UserModel {
   /**
    * Deletes a user if the viewer has access
    */
-  static async delete(viewer: Viewer, id: string): Promise<void> {
+  static async delete(viewer: Viewer, id: UUID): Promise<void> {
     // viewer can only delete their own user
     if (!canEditUser(viewer, { id })) {
       throw new Forbidden(`Cannot delete user accounts other than your own.`)

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,3 +1,14 @@
+import { ValidationError } from 'class-validator'
+
 export type Viewer = string | undefined
 
 export type DateLike = Date | string
+
+// @todo real uuid type?
+export type UUID = string
+
+export interface IValidationErrors {
+  message: string
+  expose?: boolean
+  errors?: ValidationError[]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,6 +2374,15 @@
         }
       }
     },
+    "class-validator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.9.1.tgz",
+      "integrity": "sha512-3wApflrd3ywVZyx4jaasGoFt8pmo4aGLPPAEKCKCsTRWVGPilahD88q3jQjRQwja50rl9a7rsP5LAxJYwGK8/Q==",
+      "requires": {
+        "google-libphonenumber": "^3.1.6",
+        "validator": "10.4.0"
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -3022,7 +3031,7 @@
     },
     "dotenv": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
       "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
     },
     "duplexer3": {
@@ -4418,6 +4427,11 @@
           "dev": true
         }
       }
+    },
+    "google-libphonenumber": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.2.tgz",
+      "integrity": "sha512-ubjGeosYPeusjYbUHy76lCniGTTI0k1rIFc+uKBX+jHQLDmWOSUtlFUxaeoLJ+Y+PAMM6dWp+C1HjHx5BI8kEw=="
     },
     "got": {
       "version": "6.7.1",
@@ -10530,6 +10544,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validator": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.4.0.tgz",
+      "integrity": "sha512-Q/wBy3LB1uOyssgNlXSRmaf22NxjvDNZM2MtIQ4jaEOAB61xsh1TQxsq1CgzUMBV1lDrVMogIh8GjG1DYW0zLg=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -10816,7 +10835,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "apollo-server-express": "^2.3.1",
     "bcrypt": "^3.0.3",
     "body-parser": "^1.18.3",
+    "class-validator": "^0.9.1",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "express-jwt": "^5.3.1",


### PR DESCRIPTION
Closes #15 

This PR introduces model validation which gets run before `.save()`. If there are any invalid properties  we will `throw` them in an error that includes multiple sub `errors` as a property. 

We can use this error object to relay errors via graphql or rest endpoints later.