### PR TITLE
Format errors and add authentication in GraphQL

### DIFF
--- a/app/graphql/auth/Mutation.ts
+++ b/app/graphql/auth/Mutation.ts
@@ -1,0 +1,12 @@
+import { IContext, IMutationInput } from '../types'
+import { UserModel } from '../../models/user'
+
+export default {
+  async authenticate(
+    _root,
+    args: IMutationInput<{ email: string; password: string }>,
+    ctx: IContext
+  ): Promise<{ token: string }> {
+    return UserModel.authenticate(ctx.viewer, args.input)
+  }
+}

--- a/app/graphql/auth/auth.graphql
+++ b/app/graphql/auth/auth.graphql
@@ -1,0 +1,17 @@
+extend type Mutation {
+  # Authenticate a user
+  authenticate(input: AuthenticationInput!): AuthenticationPayload!
+}
+
+input AuthenticationInput {
+  # The email address to authenticate
+  email: String!
+  # The password associated with the email address
+  password: String!
+}
+
+type AuthenticationPayload {
+  # The jwt token to be used in private/authenticated requests
+  token: String
+  # TODO: error types?
+}

--- a/app/graphql/auth/index.ts
+++ b/app/graphql/auth/index.ts
@@ -1,0 +1,9 @@
+import fs from 'fs'
+import path from 'path'
+import Mutation from './Mutation'
+
+export const typeDef = fs.readFileSync(path.join(__dirname, './auth.graphql'), 'utf8')
+
+export const resolvers = {
+  Mutation
+}

--- a/app/graphql/formatError.ts
+++ b/app/graphql/formatError.ts
@@ -1,0 +1,48 @@
+import { ApolloError, UserInputError, toApolloError } from 'apollo-server-express'
+import { get } from 'lodash'
+import logger from '../lib/logger'
+import config from '../../config'
+
+/** Converts http status codes into Apollo-style error codes */
+function toApolloErrorCode(status: number): string | undefined {
+  switch (status) {
+    case 400:
+      return 'BAD_USER_INPUT'
+    case 401:
+      return 'UNAUTHENTICATED'
+    case 403:
+      return 'FORBIDDEN'
+    case 404:
+      return 'NOT_FOUND'
+    case 409:
+      return 'CONFLICT'
+    default:
+      return undefined
+  }
+}
+
+export default function formatError(error): Error {
+  logger.error(error)
+
+  // Remove exception information in production mode
+  if (config.get('NODE_ENV') === 'production') {
+    delete error.extensions.exception
+  }
+
+  // Only explicitly exposable errors should be returned as-is
+  const canExposeError = get(error, 'originalError.expose', false)
+  if (canExposeError) {
+    // Handle validation errors separately, so we can optimize the presentation through Apollo
+    const validationErrors = get(error, 'originalError.validationErrors')
+    if (Array.isArray(validationErrors) && validationErrors.length) {
+      return new UserInputError(error.message, { validationErrors })
+    }
+
+    const status = get(error, 'originalError.status')
+    // Adorn error with an appropriate "code" so Apollo doesn't return all error types as "INTERNAL_SERVER_ERROR"
+    return toApolloError(error, toApolloErrorCode(status))
+  }
+
+  // Otherwise return a generic Apollo error
+  return new ApolloError('Internal server error')
+}

--- a/app/graphql/index.ts
+++ b/app/graphql/index.ts
@@ -1,18 +1,24 @@
 import { ApolloServer } from 'apollo-server-express'
 import { Express } from 'express'
 import schema from './schema'
+import formatError from './formatError'
 import { verifyJwt } from '../lib/auth'
 
 const path = '/graphql'
 
-const server = new ApolloServer({
-  schema,
-  // enable introspection in production mode
-  introspection: true,
-  context: ({ req }) => ({
+function context({ req }) {
+  return {
     // TODO: enrich with other user data
     viewer: req.user ? req.user.sub : undefined
-  })
+  }
+}
+
+const server = new ApolloServer({
+  schema,
+  context,
+  formatError,
+  // enable introspection (in production mode, too)
+  introspection: true
 })
 
 export default function applyGraphQLMiddleware(app: Express): void {

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -1,8 +1,9 @@
 import { merge } from 'lodash'
+import { resolvers as authResolvers } from './auth'
 import { resolvers as listResolvers } from './list'
 import { resolvers as taskResolvers } from './task'
 import { resolvers as userResolvers } from './user'
 
 const rootResolvers = {}
 
-export default merge(rootResolvers, listResolvers, taskResolvers, userResolvers)
+export default merge(rootResolvers, authResolvers, listResolvers, taskResolvers, userResolvers)

--- a/app/graphql/typeDefs.ts
+++ b/app/graphql/typeDefs.ts
@@ -1,4 +1,5 @@
 import { gql } from 'apollo-server-express'
+import { typeDef as Auth } from './auth'
 import { typeDef as List } from './list'
 import { typeDef as Task } from './task'
 import { typeDef as User } from './user'
@@ -14,4 +15,4 @@ const schema = gql`
   type Mutation
 `
 
-export default [schema, List, Task, User]
+export default [schema, Auth, List, Task, User]

--- a/app/middleware/errors.ts
+++ b/app/middleware/errors.ts
@@ -13,7 +13,7 @@ export default function handleErrorResponse(error: IError, _req: Request, res: R
   const status = error.status || 500
   let message = 'Server Error'
 
-  if (typeof error.expose !== 'boolean' || error.expose) {
+  if (error.expose) {
     message = message
   }
 

--- a/app/models/ValidationError.ts
+++ b/app/models/ValidationError.ts
@@ -1,0 +1,12 @@
+import { ValidationError as ModelValidationError } from 'class-validator'
+
+export default class ValidationError extends Error {
+  expose: boolean = true
+  status: number = 400
+  validationErrors: ModelValidationError[]
+
+  constructor(message: string, validationErrors: ModelValidationError[]) {
+    super(message)
+    this.validationErrors = validationErrors
+  }
+}

--- a/app/models/list/list.entity.ts
+++ b/app/models/list/list.entity.ts
@@ -14,7 +14,8 @@ import {
 import { validate as validateEntity, IsDate, Length, ValidateNested, IsUUID } from 'class-validator'
 import Task from '../task/task.entity'
 import User from '../user/user.entity'
-import { UUID, IValidationErrors } from '../../types'
+import { UUID } from '../../types'
+import ValidationError from '../ValidationError'
 
 @Entity('list')
 export default class List {
@@ -72,10 +73,7 @@ export default class List {
   async validate(): Promise<void> {
     const errors = await validateEntity(this, { skipMissingProperties: true })
     if (errors.length > 0) {
-      const error: IValidationErrors = new Error(`Invalid data. Check "errors" for more details.`)
-      error.expose = true
-      error.errors = errors
-      throw error
+      throw new ValidationError(`Invalid data. Check "errors" for more details.`, errors)
     }
   }
 }

--- a/app/models/task/task.entity.ts
+++ b/app/models/task/task.entity.ts
@@ -12,7 +12,8 @@ import {
 import { validate as validateEntity, IsDate, ValidateNested, IsUUID, IsDefined } from 'class-validator'
 import List from '../list/list.entity'
 import User from '../user/user.entity'
-import { DateLike, UUID, IValidationErrors } from '../../types'
+import { DateLike, UUID } from '../../types'
+import ValidationError from '../ValidationError'
 
 @Entity('task')
 export default class Task {
@@ -73,10 +74,7 @@ export default class Task {
   async validate(): Promise<void> {
     const errors = await validateEntity(this, { skipMissingProperties: true })
     if (errors.length > 0) {
-      const error: IValidationErrors = new Error(`Invalid data. Check "errors" for more details.`)
-      error.expose = true
-      error.errors = errors
-      throw error
+      throw new ValidationError(`Invalid data. Check "errors" for more details.`, errors)
     }
   }
 }

--- a/app/models/user/user.entity.ts
+++ b/app/models/user/user.entity.ts
@@ -11,7 +11,8 @@ import {
 } from 'typeorm'
 import { validate as validateEntity, Length, IsEmail, IsDate } from 'class-validator'
 import { hashPassword } from '../../lib/auth'
-import { IValidationErrors, UUID } from '../../types'
+import { UUID } from '../../types'
+import ValidationError from '../ValidationError'
 // import List from '../list/list.entity'
 
 @Entity('user')
@@ -65,10 +66,7 @@ export default class User {
   async validate(): Promise<void> {
     const errors = await validateEntity(this, { skipMissingProperties: true })
     if (errors.length > 0) {
-      const error: IValidationErrors = new Error(`Invalid data. Check "errors" for more details.`)
-      error.expose = true
-      error.errors = errors
-      throw error
+      throw new ValidationError(`Invalid data. Check "errors" for more details.`, errors)
     }
   }
 }

--- a/app/rest/users.ts
+++ b/app/rest/users.ts
@@ -2,9 +2,8 @@
  * @overview user route handlers
  */
 
-import { NotFound, Unauthorized } from 'http-errors'
+import { NotFound } from 'http-errors'
 import { get } from 'lodash'
-import { comparePassword, generateJwt } from '../lib/auth'
 import { UserModel } from '../models/user'
 
 export async function me(req, res, next) {
@@ -46,20 +45,8 @@ export async function authenticate(req, res, next) {
   try {
     const viewer = get(req, 'user.sub')
     const { email, password } = req.body
-    const user = await UserModel.fetchByEmail(viewer, email)
-
-    if (!user) {
-      throw new NotFound(`No user found with email address: "${email}"`)
-    }
-
-    const isMatch = await comparePassword(password, user.password)
-
-    if (!isMatch) {
-      throw new Unauthorized(`We didn't recognize that combination of email and password.`)
-    }
-
-    const token = generateJwt({ sub: user.id })
-    res.status(200).json({ token })
+    const result = await UserModel.authenticate(viewer, { email, password })
+    res.status(200).json(result)
   } catch (error) {
     next(error)
   }

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,14 +1,6 @@
-import { ValidationError } from 'class-validator'
-
 export type Viewer = string | undefined
 
 export type DateLike = Date | string
 
 // @todo real uuid type?
 export type UUID = string
-
-export interface IValidationErrors {
-  message: string
-  expose?: boolean
-  errors?: ValidationError[]
-}


### PR DESCRIPTION
This PR adds authentication to the GraphQL schema and enhances error handling with apollo's `formatError`.

This allows us to continue using http-errors and a special `ValidationError` class that extends `class-validator` properties.

Closes #17 