### PR TITLE
s/payload/response for mutations

### DIFF
--- a/app/graphql/auth/auth.graphql
+++ b/app/graphql/auth/auth.graphql
@@ -1,6 +1,6 @@
 extend type Mutation {
   # Authenticate a user
-  authenticate(input: AuthenticationInput!): AuthenticationPayload!
+  authenticate(input: AuthenticationInput!): AuthenticationResponse!
 }
 
 input AuthenticationInput {
@@ -10,7 +10,7 @@ input AuthenticationInput {
   password: String!
 }
 
-type AuthenticationPayload {
+type AuthenticationResponse {
   # The jwt token to be used in private/authenticated requests
   token: String
   # TODO: error types?

--- a/app/graphql/list/list.graphql
+++ b/app/graphql/list/list.graphql
@@ -5,15 +5,15 @@ extend type Query {
 
 extend type Mutation {
   # Creates a new list
-  createList(input: CreateListInput!): CreateListPayload!
+  createList(input: CreateListInput!): CreateListResponse!
   # Renames an existing list
-  renameList(input: RenameListInput!): RenameListPayload!
+  renameList(input: RenameListInput!): RenameListResponse!
   # Archives an existing list
-  archiveList(input: ArchiveListInput!): ArchiveListPayload!
+  archiveList(input: ArchiveListInput!): ArchiveListResponse!
   # Unarchives an archived list
-  unarchiveList(input: UnarchiveListInput!): UnarchiveListPayload!
+  unarchiveList(input: UnarchiveListInput!): UnarchiveListResponse!
   # Deletes a list
-  deleteList(input: DeleteListInput!): DeleteListPayload!
+  deleteList(input: DeleteListInput!): DeleteListResponse!
 }
 
 type List {
@@ -47,7 +47,7 @@ input CreateListInput {
 }
 
 # The response payload from creating a list
-type CreateListPayload {
+type CreateListResponse {
   # The newly created list
   list: List
   # TODO: error types?
@@ -62,7 +62,7 @@ input RenameListInput {
 }
 
 # The response payload from renaming a list
-type RenameListPayload {
+type RenameListResponse {
   # The renamed list
   list: List
   # TODO: error types?
@@ -75,7 +75,7 @@ input ArchiveListInput {
 }
 
 # The response payload for archiving a list
-type ArchiveListPayload {
+type ArchiveListResponse {
   list: List
 }
 
@@ -86,7 +86,7 @@ input UnarchiveListInput {
 }
 
 # The response payload for unarchiving a list
-type UnarchiveListPayload {
+type UnarchiveListResponse {
   list: List
 }
 
@@ -97,7 +97,7 @@ input DeleteListInput {
 }
 
 # The response payload from deleting a list
-type DeleteListPayload {
+type DeleteListResponse {
   # The id of the list that was deleted
   id: String
   # TODO: error types?

--- a/app/graphql/task/task.graphql
+++ b/app/graphql/task/task.graphql
@@ -4,15 +4,15 @@ extend type Query {
 
 extend type Mutation {
   # Creates a new task
-  createTask(input: CreateTaskInput!): CreateTaskPayload!
+  createTask(input: CreateTaskInput!): CreateTaskResponse!
   # Update an existing task
-  updateTask(input: UpdateTaskInput!): UpdateTaskPayload!
+  updateTask(input: UpdateTaskInput!): UpdateTaskResponse!
   # Mark a task complete
-  completeTask(input: CompleteTaskInput!): CompleteTaskPayload!
+  completeTask(input: CompleteTaskInput!): CompleteTaskResponse!
   # Mark a task incomplete
-  reopenTask(input: ReopenTaskInput!): ReopenTaskPayload!
+  reopenTask(input: ReopenTaskInput!): ReopenTaskResponse!
   # Delets a task
-  deleteTask(input: DeleteTaskInput!): DeleteTaskPayload!
+  deleteTask(input: DeleteTaskInput!): DeleteTaskResponse!
 }
 
 type Task {
@@ -51,7 +51,7 @@ input CreateTaskInput {
 }
 
 # The response payload for creating a task
-type CreateTaskPayload {
+type CreateTaskResponse {
   # The newly created task
   task: Task
   # TODO: error types?
@@ -71,7 +71,7 @@ input UpdateTaskInput {
 }
 
 # The response payload from updating a task
-type UpdateTaskPayload {
+type UpdateTaskResponse {
   task: Task
   # TODO: error types?
 }
@@ -83,7 +83,7 @@ input CompleteTaskInput {
 }
 
 # The response payload from completing a task
-type CompleteTaskPayload {
+type CompleteTaskResponse {
   # The completed task
   task: Task
   # TODO: error types?
@@ -96,7 +96,7 @@ input ReopenTaskInput {
 }
 
 # The response payload from reopening (marking incomplete) a task
-type ReopenTaskPayload {
+type ReopenTaskResponse {
   # The reopened task
   task: Task
   # TODO: error types?
@@ -109,7 +109,7 @@ input DeleteTaskInput {
 }
 
 # The response payload from deleting a task
-type DeleteTaskPayload {
+type DeleteTaskResponse {
   # The id of the task that was deleted
   id: String
   # TODO: error types?


### PR DESCRIPTION
This PR is a simple name change. Rather than calling all mutation responses `*Payload` we'll use `*Response` which is a bit more semantic.