### PR TITLE
use custom Date, DateTime scalars and built-in ID scalar

### DIFF
--- a/app/graphql/list/list.graphql
+++ b/app/graphql/list/list.graphql
@@ -1,5 +1,7 @@
 extend type Query {
+  # Lookup a list by id.
   list(id: String!): List
+  # Get the lists the user owns.
   lists(ids: [String]): [List]
 }
 
@@ -17,23 +19,20 @@ extend type Mutation {
 }
 
 type List {
-  # TODO: use UUID type
-  id: String!
+  # The unique identifier for a List (that can be used as a cache key or to refetch this object)
+  id: ID!
   # The name of the list
   name: String!
   # Whether or not the list is archived
   isArchived: Boolean!
   # The user id who created the list
-  createdBy: String
+  createdBy: String!
   # When the list was created
-  # TODO: ISO 8601 DateTime
-  createdAt: String
+  createdAt: DateTime!
   # When the list was last updated
-  # TODO: ISO 8601 DateTime
-  updatedAt: String
+  updatedAt: DateTime!
   # When the list was archived, null if not archived
-  # TODO: ISO 8601 DateTime
-  archivedAt: String
+  archivedAt: DateTime!
 
   # The associated tasks
   tasks: [Task!]

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -1,9 +1,15 @@
 import { merge } from 'lodash'
+import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date'
 import { resolvers as authResolvers } from './auth'
 import { resolvers as listResolvers } from './list'
 import { resolvers as taskResolvers } from './task'
 import { resolvers as userResolvers } from './user'
 
-const rootResolvers = {}
+const scalarResolvers = {
+  // Custom ISO 8601 date (no time) resolver
+  Date: GraphQLDate,
+  // Custom ISO 8601 UTC datetime
+  DateTime: GraphQLDateTime
+}
 
-export default merge(rootResolvers, authResolvers, listResolvers, taskResolvers, userResolvers)
+export default merge(scalarResolvers, authResolvers, listResolvers, taskResolvers, userResolvers)

--- a/app/graphql/task/task.graphql
+++ b/app/graphql/task/task.graphql
@@ -16,7 +16,7 @@ extend type Mutation {
 }
 
 type Task {
-  # The unique identifier for a ___ (can be used as a cache key or to refetch this object)
+  # The unique identifier for a Task (that can be used as a cache key or to refetch this object)
   id: ID!
   # The content of the task
   content: String!

--- a/app/graphql/task/task.graphql
+++ b/app/graphql/task/task.graphql
@@ -16,26 +16,22 @@ extend type Mutation {
 }
 
 type Task {
-  # TODO: use UUID type
-  id: String!
+  # The unique identifier for a ___ (can be used as a cache key or to refetch this object)
+  id: ID!
   # The content of the task
   content: String!
   # Whether or not the task is marked as complete
   isCompleted: Boolean!
   # The associated list this task belongs to
-  listId: String
+  listId: ID
   # The user id who created the task
-  # TODO: connect to type PublicUser
   createdBy: String
   # When the task was created
-  # TODO: ISO 8601 DateTime
-  createdAt: String
+  createdAt: DateTime!
   # When the task was last updated
-  # TODO: ISO 8601 DateTime
-  updatedAt: String
+  updatedAt: DateTime!
   # When the task was completed, null if not completed
-  # TODO: ISO 8601 DateTime
-  completedAt: String
+  completedAt: DateTime!
 
   # TODO: evaluate exposing 'list' field to find associated parent list
   # (which could result in circular references: task.list.tasks[0].list.tasks etc)
@@ -46,8 +42,7 @@ input CreateTaskInput {
   # The content of the task
   content: String!
   # The id of a list that this task should belong to (optionally)
-  # TODO: use UUID type?
-  listId: String
+  listId: ID
 }
 
 # The response payload for creating a task
@@ -67,7 +62,7 @@ input UpdateTaskInput {
   # The (optional) state of the task
   isCompleted: Boolean
   # The (optional) timestamp of completion
-  completedAt: String
+  completedAt: DateTime
 }
 
 # The response payload from updating a task

--- a/app/graphql/typeDefs.ts
+++ b/app/graphql/typeDefs.ts
@@ -10,9 +10,15 @@ const schema = gql`
     mutation: Mutation
   }
 
-  # These will get extended later
+  # Root Query and Mutation defined so they can be extended in other schema parts.
   type Query
   type Mutation
+
+  # An ISO-8601 UTC datetime.
+  scalar DateTime
+
+  # An ISO-8601 date (without time).
+  scalar Date
 `
 
 export default [schema, Auth, List, Task, User]

--- a/app/graphql/user/user.graphql
+++ b/app/graphql/user/user.graphql
@@ -1,17 +1,15 @@
 extend type Query {
-  # Get the current user
-  me: PrivateUser
+  # The currently authenticated user.
+  me: User
 }
 
-type PrivateUser {
-  # TODO: use UUID type
-  id: String!
+type User {
+  # The unique identifier for a User (that can be used as a cache key or to refetch this object)
+  id: ID!
   # The user's email address
   email: String!
-  # When the task was created
-  # TODO: ISO 8601 DateTime
-  createdAt: String
-  # When the task was last updated
-  # TODO: ISO 8601 DateTime
-  updatedAt: String
+  # When the user was created
+  createdAt: DateTime!
+  # When the user was last updated
+  updatedAt: DateTime!
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4474,6 +4474,11 @@
         "@apollographql/apollo-tools": "^0.2.6"
       }
     },
+    "graphql-iso-date": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
+      "integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
+    },
     "graphql-subscriptions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.16.4",
     "express-jwt": "^5.3.1",
     "graphql": "^0.13.2",
+    "graphql-iso-date": "^3.6.1",
     "helmet": "^3.15.0",
     "http-errors": "^1.7.1",
     "jsonwebtoken": "^8.4.0",


### PR DESCRIPTION
Closes #24 

This PR introduces a new custom scalar for Date and DateTime based on ISO 8601.

It also switched any unique identifiers to use the built-in `ID` scalar.