### PR TITLE
Add Node interface, use ID more, encapsulate root resolvers/typeDefs

### DIFF
--- a/app/graphql/list/list.graphql
+++ b/app/graphql/list/list.graphql
@@ -1,8 +1,8 @@
 extend type Query {
   # Lookup a list by id.
-  list(id: String!): List
+  list(id: ID!): List
   # Get the lists the user owns.
-  lists(ids: [String]): [List]
+  lists(ids: [ID]): [List]
 }
 
 extend type Mutation {
@@ -18,7 +18,7 @@ extend type Mutation {
   deleteList(input: DeleteListInput!): DeleteListResponse!
 }
 
-type List {
+type List implements Node {
   # The unique identifier for a List (that can be used as a cache key or to refetch this object)
   id: ID!
   # The name of the list
@@ -26,7 +26,7 @@ type List {
   # Whether or not the list is archived
   isArchived: Boolean!
   # The user id who created the list
-  createdBy: String!
+  createdBy: ID!
   # When the list was created
   createdAt: DateTime!
   # When the list was last updated
@@ -55,7 +55,7 @@ type CreateListResponse {
 # The input variables for renaming a list
 input RenameListInput {
   # The id of the list to rename
-  id: String!
+  id: ID!
   # The new name of the list
   name: String!
 }
@@ -70,7 +70,7 @@ type RenameListResponse {
 # The input variables for archiving a list
 input ArchiveListInput {
   # The id of the list you want to archive
-  id: String!
+  id: ID!
 }
 
 # The response payload for archiving a list
@@ -81,7 +81,7 @@ type ArchiveListResponse {
 # The input variables for unarchiving a list
 input UnarchiveListInput {
   # The id of the list you want to unarchive
-  id: String!
+  id: ID!
 }
 
 # The response payload for unarchiving a list
@@ -92,12 +92,12 @@ type UnarchiveListResponse {
 # The input variables to delete a list
 input DeleteListInput {
   # The id of the list you wish to delete
-  id: String!
+  id: ID!
 }
 
 # The response payload from deleting a list
 type DeleteListResponse {
   # The id of the list that was deleted
-  id: String
+  id: ID
   # TODO: error types?
 }

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -1,15 +1,8 @@
 import { merge } from 'lodash'
-import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date'
+import { resolvers as rootResolvers } from './root'
 import { resolvers as authResolvers } from './auth'
 import { resolvers as listResolvers } from './list'
 import { resolvers as taskResolvers } from './task'
 import { resolvers as userResolvers } from './user'
 
-const scalarResolvers = {
-  // Custom ISO 8601 date (no time) resolver
-  Date: GraphQLDate,
-  // Custom ISO 8601 UTC datetime
-  DateTime: GraphQLDateTime
-}
-
-export default merge(scalarResolvers, authResolvers, listResolvers, taskResolvers, userResolvers)
+export default merge(rootResolvers, authResolvers, listResolvers, taskResolvers, userResolvers)

--- a/app/graphql/root/index.ts
+++ b/app/graphql/root/index.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+import path from 'path'
+import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date'
+
+export const typeDef = fs.readFileSync(path.join(__dirname, './schema.graphql'), 'utf8')
+
+export const resolvers = {
+  // Custom ISO 8601 date (no time) resolver
+  Date: GraphQLDate,
+
+  // Custom ISO 8601 UTC datetime
+  DateTime: GraphQLDateTime
+}

--- a/app/graphql/root/schema.graphql
+++ b/app/graphql/root/schema.graphql
@@ -1,0 +1,20 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+# Root Query and Mutation defined so they can be extended in other schema parts.
+type Query
+type Mutation
+
+# An ISO-8601 UTC datetime.
+scalar DateTime
+
+# An ISO-8601 date (without time).
+scalar Date
+
+# An object with an ID.
+interface Node {
+  # ID of the object.
+  id: ID!
+}

--- a/app/graphql/task/task.graphql
+++ b/app/graphql/task/task.graphql
@@ -1,5 +1,5 @@
 extend type Query {
-  tasks(ids: [String]): [Task]
+  tasks(ids: [ID]): [Task]
 }
 
 extend type Mutation {
@@ -15,7 +15,7 @@ extend type Mutation {
   deleteTask(input: DeleteTaskInput!): DeleteTaskResponse!
 }
 
-type Task {
+type Task implements Node {
   # The unique identifier for a Task (that can be used as a cache key or to refetch this object)
   id: ID!
   # The content of the task
@@ -55,13 +55,13 @@ type CreateTaskResponse {
 # The input variables for updating a task
 input UpdateTaskInput {
   # The id of the task to update
-  id: String!
+  id: ID!
   # The (optional) new content for the task
   # When omitted, the content will not change
   content: String
   # The (optional) state of the task
   isCompleted: Boolean
-  # The (optional) timestamp of completion
+  # The (optional) datetime of completion
   completedAt: DateTime
 }
 
@@ -74,7 +74,7 @@ type UpdateTaskResponse {
 # The input variables to close/complete a task
 input CompleteTaskInput {
   # The id of the task to complete
-  id: String!
+  id: ID!
 }
 
 # The response payload from completing a task
@@ -87,7 +87,7 @@ type CompleteTaskResponse {
 # The input variables to reopen a task
 input ReopenTaskInput {
   # The id of the task to reopen
-  id: String!
+  id: ID!
 }
 
 # The response payload from reopening (marking incomplete) a task
@@ -100,12 +100,12 @@ type ReopenTaskResponse {
 # The input variables to delete a task
 input DeleteTaskInput {
   # The id of the task you wish to delete
-  id: String!
+  id: ID!
 }
 
 # The response payload from deleting a task
 type DeleteTaskResponse {
   # The id of the task that was deleted
-  id: String
+  id: ID
   # TODO: error types?
 }

--- a/app/graphql/task/task.graphql
+++ b/app/graphql/task/task.graphql
@@ -25,7 +25,7 @@ type Task implements Node {
   # The associated list this task belongs to
   listId: ID
   # The user id who created the task
-  createdBy: String
+  createdBy: ID!
   # When the task was created
   createdAt: DateTime!
   # When the task was last updated

--- a/app/graphql/typeDefs.ts
+++ b/app/graphql/typeDefs.ts
@@ -19,6 +19,12 @@ const schema = gql`
 
   # An ISO-8601 date (without time).
   scalar Date
+
+  # An object with an ID.
+  interface Node {
+    # ID of the object.
+    id: ID!
+  }
 `
 
 export default [schema, Auth, List, Task, User]

--- a/app/graphql/typeDefs.ts
+++ b/app/graphql/typeDefs.ts
@@ -1,30 +1,7 @@
-import { gql } from 'apollo-server-express'
+import { typeDef as RootSchema } from './root'
 import { typeDef as Auth } from './auth'
 import { typeDef as List } from './list'
 import { typeDef as Task } from './task'
 import { typeDef as User } from './user'
 
-const schema = gql`
-  schema {
-    query: Query
-    mutation: Mutation
-  }
-
-  # Root Query and Mutation defined so they can be extended in other schema parts.
-  type Query
-  type Mutation
-
-  # An ISO-8601 UTC datetime.
-  scalar DateTime
-
-  # An ISO-8601 date (without time).
-  scalar Date
-
-  # An object with an ID.
-  interface Node {
-    # ID of the object.
-    id: ID!
-  }
-`
-
-export default [schema, Auth, List, Task, User]
+export default [RootSchema, Auth, List, Task, User]

--- a/app/graphql/user/user.graphql
+++ b/app/graphql/user/user.graphql
@@ -3,7 +3,7 @@ extend type Query {
   me: User
 }
 
-type User {
+type User implements Node {
   # The unique identifier for a User (that can be used as a cache key or to refetch this object)
   id: ID!
   # The user's email address


### PR DESCRIPTION
A few minor tweaks here:
- using ID throughout (instead of String) where more semantic
- `interface Node` for any type of object
- move root resolvers and typeDefs into folder to match the rest of the import structure 