### PR TITLE
include resolve type for Node interface

### DIFF
--- a/app/graphql/root/index.ts
+++ b/app/graphql/root/index.ts
@@ -9,5 +9,13 @@ export const resolvers = {
   Date: GraphQLDate,
 
   // Custom ISO 8601 UTC datetime
-  DateTime: GraphQLDateTime
+  DateTime: GraphQLDateTime,
+
+  // Apollo Server 2 aims to make the defaults follow best practices, such as defining type resolution for unions/interfaces
+  // @see {@link https://github.com/apollographql/apollo-server/issues/1075}
+  Node: {
+    __resolveType() {
+      return null
+    }
+  }
 }


### PR DESCRIPTION
In order to appease Apollo Server 2 complaining about `interface Node` not having a resolve type:

>Apollo Server 2 aims to make the defaults follow best practices, such as defining type resolution for unions/interfaces: https://github.com/apollographql/apollo-server/issues/1075