### PR TITLE
move query logic into one place and make list names editable

### DIFF
--- a/client/src/@types/type-helpers.ts
+++ b/client/src/@types/type-helpers.ts
@@ -1,3 +1,5 @@
-export type Difference<A, B> = Pick<A, Exclude<keyof A, keyof B>>
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+
+export type Difference<T, K> = Omit<T, keyof K>
 
 export type Maybe<T> = T | null

--- a/client/src/components/InlineEditableTextField/InlineEdit.tsx
+++ b/client/src/components/InlineEditableTextField/InlineEdit.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import InlineEditUncontrolled, { InlineEditProps } from './InlineEditUncontrolled'
+import { Omit } from '../../@types/type-helpers'
+
+type Props = Omit<InlineEditProps,
+  | 'onCancel'
+  | 'isEditing'
+  | 'onEditRequested'
+>
+
+interface State {
+  isEditing: boolean
+}
+
+export default class InlineEdit extends React.Component<Props, State> {
+  state = {
+    isEditing: false
+  }
+
+  onConfirm = () => {
+    this.setState({ isEditing: false })
+    this.props.onConfirm()
+  }
+
+  onCancel = () => {
+    this.setState({ isEditing: false })
+  }
+
+  onEditRequested = () => {
+    this.setState({ isEditing: true })
+  }
+
+  render() {
+    return (
+      <InlineEditUncontrolled
+        {...this.props}
+        onConfirm={this.onConfirm}
+        onCancel={this.onCancel}
+        isEditing={this.state.isEditing}
+        onEditRequested={this.onEditRequested}
+      />
+    )
+  }
+}

--- a/client/src/components/InlineEditableTextField/InlineEditUncontrolled.tsx
+++ b/client/src/components/InlineEditableTextField/InlineEditUncontrolled.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import Box from 'ui-box'
+
+export interface InlineEditProps {
+  editView: React.ReactNode
+  readView: React.ReactNode
+  onCancel: () => void
+  onConfirm: () => void
+  isEditing: boolean
+  onEditRequested: (event: React.SyntheticEvent) => void
+}
+
+interface State {
+  wrapperFocused: boolean
+}
+
+export default class InlineEditUncontrolled extends React.Component<InlineEditProps, State> {
+  confirmOnBlur = () => {
+    // if the wrapper receives blur we should trigger the confirm handler
+    if (!this.state.wrapperFocused) {
+      this.props.onConfirm()
+    }
+  }
+
+  onWrapperBlur = () => {
+    if (!this.props.isEditing) {
+      return
+    }
+
+    this.setState({ wrapperFocused: false }, () => this.confirmOnBlur())
+  }
+
+  onWrapperClick = (event: React.SyntheticEvent) => {
+    if (!this.props.isEditing) {
+      this.props.onEditRequested(event)
+    }
+  }
+
+  onWrapperFocus = () => {
+    this.setState({ wrapperFocused: true })
+  }
+
+  render() {
+    const { editView, readView, isEditing } = this.props
+
+    return (
+      <Box onBlur={this.onWrapperBlur} onFocus={this.onWrapperFocus}>
+        {isEditing
+          ? editView
+          : <Box onClick={this.onWrapperClick}>{readView}</Box>
+        }
+      </Box>
+    )
+  }
+}

--- a/client/src/components/InlineEditableTextField/index.tsx
+++ b/client/src/components/InlineEditableTextField/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './InlineEdit'
+export { default as InlineEditUncontrolled } from './InlineEditUncontrolled'

--- a/client/src/components/ListDetail/queries.ts
+++ b/client/src/components/ListDetail/queries.ts
@@ -1,4 +1,5 @@
 import { Maybe } from '../../@types/type-helpers'
+import client from '../../lib/graphql-client'
 
 export interface Task {
   id: string
@@ -19,11 +20,11 @@ export interface List {
   tasks: Task[]
 }
 
-export interface GetListData {
+interface GetListData {
   list: Maybe<List>
 }
 
-export const getListQuery = `
+const getListQuery = `
   query GetList($id: ID!) {
     list(id: $id) {
       id
@@ -44,3 +45,42 @@ export const getListQuery = `
     }
   }
 `
+
+export function getList(id: string) {
+  return client.request<GetListData>(getListQuery, { id })
+}
+
+interface RenameListData {
+  renameList: {
+    list: Maybe<List>
+  }
+}
+
+interface RenameListVariables {
+  input: {
+    id: string
+    name: string
+  }
+}
+
+export const renameListMutation = `
+  mutation RenameList($input: RenameListInput!) {
+    renameList(input: $input) {
+      list {
+        id
+        name
+      }
+    }
+  }
+`
+
+export async function renameList(id: string, name: string) {
+  const result = await client.request<RenameListData>(renameListMutation, {
+    input: {
+      id,
+      name
+    }
+  })
+
+  return result.renameList
+}

--- a/client/src/components/Lists/Lists.tsx
+++ b/client/src/components/Lists/Lists.tsx
@@ -10,7 +10,7 @@ interface List {
 interface Props {
   isCreatingList?: boolean
   lists: List[]
-  onCreateList: (name: string) => Promise<List | null>
+  onCreateList: (name: string) => Promise<void>
 }
 
 class Lists extends Component<Props> {

--- a/client/src/components/Lists/index.tsx
+++ b/client/src/components/Lists/index.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import { Maybe } from '../../@types/type-helpers'
-import client from '../../lib/graphql-client'
 import Lists from './Lists'
 import {
-  getListsQuery,
-  createListMutation,
   List,
-  GetListsData,
-  CreateListData
+  getLists,
+  createList
 } from './queries'
 
 interface State {
@@ -27,8 +24,8 @@ export default class ListsWithData extends React.PureComponent<{}, State> {
 
   async componentDidMount() {
     try {
-      const data = await client.request<GetListsData>(getListsQuery)
-      this.setState({ lists: data.lists })
+      const { lists } = await getLists()
+      this.setState({ lists })
     } catch (error) {
       // TODO add frontend Segment + error tracking
       this.setState({ error })
@@ -40,16 +37,8 @@ export default class ListsWithData extends React.PureComponent<{}, State> {
   handleCreateList = async (name: string) => {
     this.setState({ isCreatingList: true })
 
-    let list: null | List = null
-
     try {
-      const { createList } = await client.request<CreateListData>(createListMutation, {
-        input: {
-          name
-        }
-      })
-
-      list = createList.list
+      const { list } = await createList(name)
 
       if (list !== null) {
         const appended: List[] = Array.from(this.state.lists || [])
@@ -59,8 +48,6 @@ export default class ListsWithData extends React.PureComponent<{}, State> {
     } finally {
       this.setState({ isCreatingList: false })
     }
-
-    return list
   }
 
   render() {

--- a/client/src/components/Lists/queries.ts
+++ b/client/src/components/Lists/queries.ts
@@ -1,15 +1,16 @@
 import { Maybe } from '../../@types/type-helpers'
+import client from '../../lib/graphql-client'
 
 export interface List {
   id: string
   name: string
 }
 
-export interface GetListsData {
+interface GetListsData {
   lists: List[]
 }
 
-export const getListsQuery = `
+const getListsQuery = `
   query GetLists {
     lists {
       id
@@ -18,14 +19,18 @@ export const getListsQuery = `
   }
 `
 
-export interface CreateListData {
+export function getLists() {
+  return client.request<GetListsData>(getListsQuery)
+}
+
+interface CreateListData {
   createList: {
     list: Maybe<List>
   }
 }
 
-export const createListMutation = `
-  mutation createList($input: CreateListInput!) {
+const createListMutation = `
+  mutation CreateList($input: CreateListInput!) {
     createList(input: $input) {
       list {
         id
@@ -34,3 +39,13 @@ export const createListMutation = `
     }
   }
 `
+
+export async function createList(name: string) {
+  const result = await client.request<CreateListData>(createListMutation, {
+    input: {
+      name
+    }
+  })
+
+  return result.createList
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,9 +600,9 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.119":
-  version "4.14.129"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.129.tgz#9aaca391db126802482655c48dd79a814488202f"
-  integrity sha512-oYaV0eSlnOacOr7i4X1FFdH8ttSlb57gu3I9MuStIv2CYkISEY84dNHYsC3bF6sNH7qYcu1BtVrCtQ8Q4KPTfQ==
+  version "4.14.130"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.130.tgz#04b3a690d5f4fc34579963c99adae067b8c8eb5a"
+  integrity sha512-H++wk0tbneBsRVfLkgAAd0IIpmpVr2Bj4T0HncoOsQf3/xrJexRYQK2Tqo0Ej3pFslM8GkMgdis9bu6xIb1ycw==
 
 "@types/long@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
This PR adds support for renaming lists and moves all the query logic/types into one place co-located next to the components that use them so consumers only need to pass in the right input params and not worry about the details of a query shape so much.